### PR TITLE
fix: `addToCart()` function rename

### DIFF
--- a/ponder/v3_6/team02.html
+++ b/ponder/v3_6/team02.html
@@ -352,7 +352,7 @@ console.log(findProductById(productId));
                   This function should be the default export.
                 </li>
                 <li>
-                  <code>addToCart()</code>: This is the function that is
+                  <code>addProductToCart()</code>: This is the function that is
                   currently in <kbd>product.js</kbd>. We need to move it here
                 </li>
 
@@ -519,7 +519,7 @@ function productDetailsTemplate(product) {
                 </code></pre>
                 </li>
                 <li>
-                  <code>addToCart()</code>: move the code from
+                  <code>addProductToCart()</code>: move the code from
                   <kbd>product.js</kbd> for this function and make any changes
                   necessary to make it work.
                 </li>


### PR DESCRIPTION
the `addToCart()` function is now `addProductToCart()` in the sleepoutside repo. see https://github.com/matkat99/sleepoutside-v3/blob/main/src/js/product.js#L4

updated two references to the function in the team02.html file.